### PR TITLE
[Feat] 클래스와 핸들러를 사용한 예외처리

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,9 @@
 - [ ] Documentation content changes
 
 
-## What is the current behavior?
+## Current behavior
 
-## What is the new behavior?
+## New behavior?
 
 
 ## Other information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@
 
 ## Current behavior
 
-## New behavior?
+## New behavior
 
 
 ## Other information

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ dependencies {
 	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	// https://mvnrepository.com/artifact/org.flywaydb/flyway-core
-	implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.15.0'
+//	// https://mvnrepository.com/artifact/org.flywaydb/flyway-core
+//	implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.15.0'
 	// https://mvnrepository.com/artifact/org.flywaydb/flyway-mysql
 	implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '10.15.0'
 }

--- a/src/main/java/crux/crux_server/config/login/exception/JwtCustomException.java
+++ b/src/main/java/crux/crux_server/config/login/exception/JwtCustomException.java
@@ -3,20 +3,31 @@ package crux.crux_server.config.login.exception;
 import crux.crux_server.global.exception.CustomException;
 import crux.crux_server.global.exception.ErrorCode;
 
+import java.util.Map;
+
 public class JwtCustomException extends CustomException {
     protected JwtCustomException(ErrorCode errorCode) {
         super(errorCode);
+    }
+    protected JwtCustomException(ErrorCode errorCode, Map<String, String> property) {
+        super(errorCode, property);
     }
 
     public static class JwtExpiredException extends JwtCustomException {
         public JwtExpiredException() {
             super(ErrorCode.JWT_EXPIRED);
         }
+        public JwtExpiredException(Map<String, String> property) {
+            super(ErrorCode.JWT_EXPIRED, property);
+        }
     }
 
     public static class JwtInvalidException extends JwtCustomException {
         public JwtInvalidException() {
             super(ErrorCode.JWT_INVALID);
+        }
+        public JwtInvalidException(Map<String, String> property) {
+            super(ErrorCode.JWT_INVALID, property);
         }
     }
 }

--- a/src/main/java/crux/crux_server/config/login/exception/LoginException.java
+++ b/src/main/java/crux/crux_server/config/login/exception/LoginException.java
@@ -3,14 +3,22 @@ package crux.crux_server.config.login.exception;
 import crux.crux_server.global.exception.CustomException;
 import crux.crux_server.global.exception.ErrorCode;
 
+import java.util.Map;
+
 public class LoginException extends CustomException {
     protected LoginException(ErrorCode errorCode) {
         super(errorCode);
+    }
+    protected LoginException(ErrorCode errorCode, Map<String, String> property) {
+        super(errorCode, property);
     }
 
     public static class LoginFailedException extends LoginException {
         public LoginFailedException() {
             super(ErrorCode.LOGIN_FAILED);
+        }
+        public LoginFailedException(Map<String, String> property) {
+            super(ErrorCode.LOGIN_FAILED, property);
         }
     }
 }

--- a/src/main/java/crux/crux_server/config/login/jwt/JwtTokenProvider.java
+++ b/src/main/java/crux/crux_server/config/login/jwt/JwtTokenProvider.java
@@ -82,11 +82,15 @@ public class JwtTokenProvider {
 
 //    // Request의 Header에서 token 값을 가져옵니다. "Authorization" : Bearer [TOKEN 값]'
     public String resolveToken(HttpServletRequest request) {
-        String value = request.getHeader("Authorization");
-        if (value != null && value.startsWith("Bearer ")) {
-            return value.substring(7);
-        } else {
-            return null;
+        try {
+            String value = request.getHeader("Authorization");
+            if (value != null && value.startsWith("Bearer ")) {
+                return value.substring(7);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            throw  new JwtException("토큰이 유효하지 않습니다.");
         }
     }
 

--- a/src/main/java/crux/crux_server/domain/member/dto/MemberDto.java
+++ b/src/main/java/crux/crux_server/domain/member/dto/MemberDto.java
@@ -9,9 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MemberDto {
     private Long id;
-    private String phoneNumber;
     private String kakaoId;
-    private Integer coin;
-    private String state;
     private String role;
 }

--- a/src/main/java/crux/crux_server/domain/member/exception/MemberException.java
+++ b/src/main/java/crux/crux_server/domain/member/exception/MemberException.java
@@ -4,14 +4,22 @@ package crux.crux_server.domain.member.exception;
 import crux.crux_server.global.exception.CustomException;
 import crux.crux_server.global.exception.ErrorCode;
 
+import java.util.Map;
+
 public class MemberException extends CustomException {
     protected MemberException(ErrorCode errorCode) {
         super(errorCode);
+    }
+    protected MemberException(ErrorCode errorCode, Map<String, String> property) {
+        super(errorCode, property);
     }
 
     public static class MemberNotFoundException extends MemberException {
         public MemberNotFoundException() {
             super(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        public MemberNotFoundException(Map<String, String> property) {
+            super(ErrorCode.MEMBER_NOT_FOUND, property);
         }
     }
 }

--- a/src/main/java/crux/crux_server/global/exception/CustomException.java
+++ b/src/main/java/crux/crux_server/global/exception/CustomException.java
@@ -9,39 +9,39 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 @Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CustomException extends RuntimeException {
 
     private static final String EXCEPTION_INFO_BRACKET = "{ %s | %s }";
     private static final String CODE_MESSAGE = " Code: %d, Message: %s ";
-    private static final String PROPERTY_VALUE = "Property: %s, Value: %s ";
-    private static final String VALUE_DELIMITER = "/";
+    private static final String PROPERTY_VALUE = "%s=%s";
+    private static final String VALUE_DELIMITER = "; ";
     private static final String RESPONSE_MESSAGE = "%d %s";
 
     private final int code;
     private final String message;
-    private final Map<String, String> inputValuesByProperty;
+    private final Map<String, String> property;
 
     protected CustomException(final ErrorCode errorCode) {
         this(errorCode, Collections.emptyMap());
     }
 
     protected CustomException(
-        final ErrorCode errorCode,
-        final Map<String, String> inputValuesByProperty
+            final ErrorCode errorCode,
+            final Map<String, String> property
     ) {
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
-        this.inputValuesByProperty = inputValuesByProperty;
+        this.property = property;
     }
 
     public static CustomException of(
-        final ErrorCode errorCode,
-        final Map<String, String> propertyValues
+            final ErrorCode errorCode,
+            final Map<String, String> property
     ) {
-        return new CustomException(errorCode, propertyValues);
+        return new CustomException(errorCode, property);
     }
 
     public static CustomException from(final ErrorCode errorCode) {
@@ -51,16 +51,16 @@ public class CustomException extends RuntimeException {
 
     public String getErrorInfoLog() {
         final String codeMessage = String.format(CODE_MESSAGE, code, message);
-        final String errorPropertyValue = getErrorPropertyValue();
+        final String errorPropertyValue = getPropertyToString();
 
         return String.format(EXCEPTION_INFO_BRACKET, codeMessage, errorPropertyValue);
     }
 
-    private String getErrorPropertyValue() {
-        return inputValuesByProperty.entrySet()
-            .stream()
-            .map(entry -> String.format(PROPERTY_VALUE, entry.getKey(), entry.getValue()))
-            .collect(Collectors.joining(VALUE_DELIMITER));
+    public String getPropertyToString() {
+        return property.entrySet()
+                .stream()
+                .map(entry -> String.format(PROPERTY_VALUE, entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(VALUE_DELIMITER));
     }
 
     public String getErrorResponse() {

--- a/src/main/java/crux/crux_server/global/exception/ErrorResponse.java
+++ b/src/main/java/crux/crux_server/global/exception/ErrorResponse.java
@@ -4,14 +4,16 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Getter
-public class ErrorResponse {
+import java.util.Map;
 
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
     private int code;
     private String message;
+    private Map<String, String> property;
 
     public static ErrorResponse from(final CustomException customException) {
-        return new ErrorResponse(customException.getCode(), customException.getMessage());
+        return new ErrorResponse(customException.getCode(), customException.getMessage(), customException.getProperty());
     }
 }

--- a/src/main/java/crux/crux_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/crux/crux_server/global/exception/GlobalExceptionHandler.java
@@ -1,20 +1,108 @@
 package crux.crux_server.global.exception;
 
+import crux.crux_server.config.login.exception.JwtCustomException;
+import crux.crux_server.domain.member.exception.MemberException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-//    @ExceptionHandler(Exception.class)
-//    public ResponseEntity<ErrorResponse> handleInternalServer(final Exception e) {
-//        final CustomException customException = CustomException.from(
-//            ErrorCode.INTERNAL_SERVER_ERROR);
-//
-//        log.error(e.toString());
-//
-//        return ResponseEntity.internalServerError().body(ErrorResponse.from(customException));
-//    }
+    // 기존 유효성 검사 예외 핸들러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        final ErrorResponse response = ErrorResponse.from(CustomException.of(ErrorCode.BAD_REQUEST, errors));
+        return ResponseEntity.badRequest().body(response);
+
+    }
+
+    // 새로운 타입 미스매치 예외 핸들러
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        Map<String, String> errors = new HashMap<>();
+        String fieldName = ex.getName();
+        String errorMessage = "Invalid value for field: " + fieldName;
+        errors.put(fieldName, errorMessage);
+        final ErrorResponse response = ErrorResponse.from(CustomException.of(ErrorCode.BAD_REQUEST, errors));
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    // 잘못된 형식의 데이터 전송
+    @ExceptionHandler(HttpMessageConversionException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageConversionException(final HttpMessageConversionException e) {
+        log.error("HttpMessageConversionException", e);
+        final ErrorResponse response = ErrorResponse.from(CustomException.from(ErrorCode.BAD_REQUEST));
+        return ResponseEntity.badRequest().body(response);
+    }
+
+
+    /** 여기부터는 CustomException 처리 핸들러 */
+
+    // 400 Bad Request
+    @ExceptionHandler({
+            JwtCustomException.JwtExpiredException.class,
+            JwtCustomException.JwtInvalidException.class,
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalBadRequestException(final CustomException e) {
+        return ResponseEntity.status(BAD_REQUEST).body(ErrorResponse.from(e));
+    }
+
+    // 401 Unauthorized
+    @ExceptionHandler({
+            // 인증 오류 추가
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalUnauthorizedException(final CustomException e) {
+        return ResponseEntity.status(UNAUTHORIZED).body(ErrorResponse.from(e));
+    }
+
+    // 403 Forbidden
+    @ExceptionHandler({
+            // 권한 오류 추가
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalForbiddenException(final CustomException e) {
+        return ResponseEntity.status(FORBIDDEN).body(ErrorResponse.from(e));
+    }
+
+    // 404 Not Found
+    @ExceptionHandler({
+            MemberException.MemberNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalNotFoundException(final CustomException e) {
+        return ResponseEntity.status(NOT_FOUND).body(ErrorResponse.from(e));
+    }
+
+    // 409 Conflict
+    @ExceptionHandler({
+            // 중복 오류 추가
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalConflictException(final CustomException e) {
+        return ResponseEntity.status(CONFLICT).body(ErrorResponse.from(e));
+    }
+
+    // 500 Internal Server Error
+    @ExceptionHandler({
+            // 서버 오류 추가
+    })
+    public ResponseEntity<ErrorResponse> handleGlobalInternalServerException(final CustomException e) {
+        log.error(e.getErrorInfoLog());
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ErrorResponse.from(e));
+    }
 }

--- a/src/main/java/crux/crux_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/crux/crux_server/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package crux.crux_server.global.exception;
 import crux.crux_server.config.login.exception.JwtCustomException;
 import crux.crux_server.domain.member.exception.MemberException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.validation.FieldError;
@@ -29,7 +28,8 @@ public class GlobalExceptionHandler {
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
-        final ErrorResponse response = ErrorResponse.from(CustomException.of(ErrorCode.BAD_REQUEST, errors));
+
+        final ErrorResponse response = ErrorResponse.from(new HttpException.BadRequestException(errors));
         return ResponseEntity.badRequest().body(response);
 
     }
@@ -41,7 +41,8 @@ public class GlobalExceptionHandler {
         String fieldName = ex.getName();
         String errorMessage = "Invalid value for field: " + fieldName;
         errors.put(fieldName, errorMessage);
-        final ErrorResponse response = ErrorResponse.from(CustomException.of(ErrorCode.BAD_REQUEST, errors));
+
+        final ErrorResponse response = ErrorResponse.from(new HttpException.BadRequestException(errors));
         return ResponseEntity.badRequest().body(response);
     }
 
@@ -49,7 +50,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageConversionException.class)
     protected ResponseEntity<ErrorResponse> handleHttpMessageConversionException(final HttpMessageConversionException e) {
         log.error("HttpMessageConversionException", e);
-        final ErrorResponse response = ErrorResponse.from(CustomException.from(ErrorCode.BAD_REQUEST));
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", "Invalid request body");
+
+        final ErrorResponse response = ErrorResponse.from(new HttpException.BadRequestException(errors));
         return ResponseEntity.badRequest().body(response);
     }
 
@@ -65,21 +69,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(BAD_REQUEST).body(ErrorResponse.from(e));
     }
 
-    // 401 Unauthorized
-    @ExceptionHandler({
-            // 인증 오류 추가
-    })
-    public ResponseEntity<ErrorResponse> handleGlobalUnauthorizedException(final CustomException e) {
-        return ResponseEntity.status(UNAUTHORIZED).body(ErrorResponse.from(e));
-    }
-
-    // 403 Forbidden
-    @ExceptionHandler({
-            // 권한 오류 추가
-    })
-    public ResponseEntity<ErrorResponse> handleGlobalForbiddenException(final CustomException e) {
-        return ResponseEntity.status(FORBIDDEN).body(ErrorResponse.from(e));
-    }
+//    // 401 Unauthorized
+//    @ExceptionHandler({
+//            // 인증 오류 추가
+//    })
+//    public ResponseEntity<ErrorResponse> handleGlobalUnauthorizedException(final CustomException e) {
+//        return ResponseEntity.status(UNAUTHORIZED).body(ErrorResponse.from(e));
+//    }
+//
+//    // 403 Forbidden
+//    @ExceptionHandler({
+//            // 권한 오류 추가
+//    })
+//    public ResponseEntity<ErrorResponse> handleGlobalForbiddenException(final CustomException e) {
+//        return ResponseEntity.status(FORBIDDEN).body(ErrorResponse.from(e));
+//    }
 
     // 404 Not Found
     @ExceptionHandler({
@@ -89,20 +93,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(NOT_FOUND).body(ErrorResponse.from(e));
     }
 
-    // 409 Conflict
-    @ExceptionHandler({
-            // 중복 오류 추가
-    })
-    public ResponseEntity<ErrorResponse> handleGlobalConflictException(final CustomException e) {
-        return ResponseEntity.status(CONFLICT).body(ErrorResponse.from(e));
-    }
-
-    // 500 Internal Server Error
-    @ExceptionHandler({
-            // 서버 오류 추가
-    })
-    public ResponseEntity<ErrorResponse> handleGlobalInternalServerException(final CustomException e) {
-        log.error(e.getErrorInfoLog());
-        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ErrorResponse.from(e));
-    }
+//    // 409 Conflict
+//    @ExceptionHandler({
+//            // 중복 오류 추가
+//    })
+//    public ResponseEntity<ErrorResponse> handleGlobalConflictException(final CustomException e) {
+//        return ResponseEntity.status(CONFLICT).body(ErrorResponse.from(e));
+//    }
+//
+//    // 500 Internal Server Error
+//    @ExceptionHandler({
+//            // 서버 오류 추가
+//    })
+//    public ResponseEntity<ErrorResponse> handleGlobalInternalServerException(final CustomException e) {
+//        log.error(e.getErrorInfoLog());
+//        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ErrorResponse.from(e));
+//    }
 }

--- a/src/main/java/crux/crux_server/global/exception/HttpException.java
+++ b/src/main/java/crux/crux_server/global/exception/HttpException.java
@@ -1,13 +1,21 @@
 package crux.crux_server.global.exception;
 
+import java.util.Map;
+
 public class HttpException extends CustomException {
     protected HttpException(ErrorCode errorCode) {
         super(errorCode);
+    }
+    protected HttpException(ErrorCode errorCode, Map<String, String> property) {
+        super(errorCode, property);
     }
 
     public static class BadRequestException extends HttpException {
         public BadRequestException() {
             super(ErrorCode.BAD_REQUEST);
+        }
+        public BadRequestException(Map<String, String> property) {
+            super(ErrorCode.BAD_REQUEST, property);
         }
     }
 
@@ -15,11 +23,17 @@ public class HttpException extends CustomException {
         public UnauthorizedException() {
             super(ErrorCode.UNAUTHORIZED);
         }
+        public UnauthorizedException(Map<String, String> property) {
+            super(ErrorCode.UNAUTHORIZED, property);
+        }
     }
 
     public static class ForbiddenException extends HttpException {
         public ForbiddenException() {
             super(ErrorCode.FORBIDDEN);
+        }
+        public ForbiddenException(Map<String, String> property) {
+            super(ErrorCode.FORBIDDEN, property);
         }
     }
 
@@ -27,17 +41,26 @@ public class HttpException extends CustomException {
         public NotFoundException() {
             super(ErrorCode.NOT_FOUND);
         }
+        public NotFoundException(Map<String, String> property) {
+            super(ErrorCode.NOT_FOUND, property);
+        }
     }
 
     public static class ConflictException extends HttpException {
         public ConflictException() {
             super(ErrorCode.CONFLICT);
         }
+        public ConflictException(Map<String, String> property) {
+            super(ErrorCode.CONFLICT, property);
+        }
     }
 
     public static class InternalServerException extends HttpException {
         public InternalServerException() {
             super(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        public InternalServerException(Map<String, String> property) {
+            super(ErrorCode.INTERNAL_SERVER_ERROR, property);
         }
     }
 }

--- a/src/main/resources/db/migration/local/V1.0.0__init.sql
+++ b/src/main/resources/db/migration/local/V1.0.0__init.sql
@@ -1,4 +1,4 @@
-# role 테이블 생성
+-- # role 테이블 생성
 create table role
 (
     created_date  datetime(6)  null,
@@ -10,7 +10,7 @@ create table role
         unique (name)
 );
 
-# member 테이블 생성
+-- # member 테이블 생성
 create table member
 (
     created_date  datetime(6) null,

--- a/src/main/resources/db/migration/local/V1.0.0__init.sql
+++ b/src/main/resources/db/migration/local/V1.0.0__init.sql
@@ -1,4 +1,4 @@
--- # role 테이블 생성
+# role 테이블 생성
 create table role
 (
     created_date  datetime(6)  null,
@@ -10,7 +10,7 @@ create table role
         unique (name)
 );
 
--- # member 테이블 생성
+# member 테이블 생성
 create table member
 (
     created_date  datetime(6) null,


### PR DESCRIPTION
## Description
`RuntimeException` 클래스를 상속받은 `CustomException`을 만들고 이를 상속받은 각 예외 클래스를 만듦.
예외 클래스가 사용하는 ErrorCode는 Enum을 사용해서 따로 명시되어 있음.

예외 클래스를 그냥 사용하면 status code가 전부 500으로 설정될 뿐이기 때문에, `GlobalExceptionHandler`에서 예외 클래스 별로 상태코드를 설정하여 응답함. `ErrorResponse` 클래스로 한번 더 추상화하여 ErrorCode와 Message, Property를 전달함. 

@OverRaddit @koreanddinghwan - 스프링 공부용으로 참고만 하십쇼.

close #8 

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## Current behavior

## New behavior
- 커스텀 예외 클래스를 만들어서 예외처리
- 예외 핸들러를 등록하여 예외 클래스별로 다르게 응답을 보낼 수 있음.


## Other information
![image](https://github.com/c-r-u-x/crux-server/assets/71076926/9da5b5ac-25be-4de4-ba5c-fdb4ae4bc909)
